### PR TITLE
Into params inline

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ utoipa-gen = { version = "1.1.0", path = "./utoipa-gen" }
 [dev-dependencies]
 assert-json-diff = "2"
 actix-web = { version = "4" }
+assert-json-diff = "2"
 paste = "1"
 chrono = { version  = "0.4", features = ["serde"] }
 rust_decimal = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ serde_yaml = { version = "0.8", optional = true }
 utoipa-gen = { version = "1.1.0", path = "./utoipa-gen" }
 
 [dev-dependencies]
-assert-json-diff = "2"
 actix-web = { version = "4" }
+assert-json-diff = "2"
 paste = "1"
 chrono = { version  = "0.4", features = ["serde"] }
 rust_decimal = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ serde_yaml = { version = "0.8", optional = true }
 utoipa-gen = { version = "1.1.0", path = "./utoipa-gen" }
 
 [dev-dependencies]
-assert-json-diff = "2"
 actix-web = { version = "4" }
 assert-json-diff = "2"
 paste = "1"

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ utoipa = { version = "1", features = ["actix_extras"] }
 
 **Note!** To use `utoipa` together with Swagger UI you can use the [utoipa-swagger-ui](https://docs.rs/utoipa-swagger-ui/) crate.
 
+## Breaking changes in next release 2.0.0
+
+Please read the incoming changes from here: https://github.com/juhaku/utoipa/discussions/181.
+
 ## Examples
 
 Create a struct or it could be an enum also. Add `Component` derive macro to it so it can be registered

--- a/examples/todo-actix/src/todo.rs
+++ b/examples/todo-actix/src/todo.rs
@@ -105,13 +105,7 @@ pub(super) async fn create_todo(todo: Json<Todo>, todo_store: Data<TodoStore>) -
 
     todos
         .iter()
-        .find_map(|existing| {
-            if existing.id == todo.id {
-                Some(existing)
-            } else {
-                None
-            }
-        })
+        .find(|existing| existing.id == todo.id)
         .map(|existing| {
             HttpResponse::Conflict().json(ErrorResponse::Conflict(format!("id = {}", existing.id)))
         })
@@ -179,7 +173,7 @@ pub(super) async fn get_todo_by_id(id: Path<i32>, todo_store: Data<TodoStore>) -
 
     todos
         .iter()
-        .find_map(|todo| if todo.id == id { Some(todo) } else { None })
+        .find(|todo| todo.id == id)
         .map(|todo| HttpResponse::Ok().json(todo))
         .unwrap_or_else(|| {
             HttpResponse::NotFound().json(ErrorResponse::NotFound(format!("id = {id}")))

--- a/examples/todo-axum/src/main.rs
+++ b/examples/todo-axum/src/main.rs
@@ -193,7 +193,7 @@ mod todo {
             (status = 404, description = "Todo not found")
         ),
         params(
-            ("id" = i32, path, description = "Todo database id")
+            ("id" = i32, Path, description = "Todo database id")
         ),
         security(
             (), // <-- make optional authentication
@@ -234,7 +234,7 @@ mod todo {
             (status = 404, description = "Todo not found", body = TodoError, example = json!(TodoError::NotFound(String::from("id = 1"))))
         ),
         params(
-            ("id" = i32, path, description = "Todo database id")
+            ("id" = i32, Path, description = "Todo database id")
         ),
         security(
             ("api_key" = [])

--- a/examples/todo-tide/src/main.rs
+++ b/examples/todo-tide/src/main.rs
@@ -174,7 +174,7 @@ mod todo {
             (status = 404, description = "Todo not found", body = TodoError, example = json!(TodoError::NotFound(String::from("id = 1"))))
         ),
         params(
-            ("id" = i32, path, description = "Id of todo item to delete")
+            ("id" = i32, Path, description = "Id of todo item to delete")
         ),
         security(
             ("api_key" = [])
@@ -215,7 +215,7 @@ mod todo {
             (status = 404, description = "Todo not found", body = TodoError, example = json!(TodoError::NotFound(String::from("id = 1"))))
         ),
         params(
-            ("id" = i32, path, description = "Id of todo item to mark done")
+            ("id" = i32, Path, description = "Id of todo item to mark done")
         )
     )]
     pub(super) async fn mark_done(req: Request<Store>) -> tide::Result<Response> {

--- a/examples/todo-warp/src/main.rs
+++ b/examples/todo-warp/src/main.rs
@@ -224,7 +224,7 @@ mod todo {
             (status = 404, description = "Todo not found to delete"),
         ),
         params(
-            ("id" = i64, path, description = "Todo's unique id")
+            ("id" = i64, Path, description = "Todo's unique id")
         ),
         security(
             ("api_key" = [])

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@
 //!             (status = 404, description = "Pet was not found")
 //!         ),
 //!         params(
-//!             ("id" = u64, path, description = "Pet database id to get Pet for"),
+//!             ("id" = u64, Path, description = "Pet database id to get Pet for"),
 //!         )
 //!     )]
 //!     async fn get_pet_by_id(pet_id: u64) -> Pet {
@@ -159,7 +159,7 @@
 //! #             (status = 404, description = "Pet was not found")
 //! #         ),
 //! #         params(
-//! #             ("id" = u64, path, description = "Pet database id to get Pet for"),
+//! #             ("id" = u64, Path, description = "Pet database id to get Pet for"),
 //! #         )
 //! #     )]
 //! #     async fn get_pet_by_id(pet_id: u64) -> Pet {
@@ -344,7 +344,7 @@ pub trait Component {
 ///         (status = 404, description = "Pet was not found")
 ///     ),
 ///     params(
-///         ("id" = u64, path, description = "Pet database id to get Pet for"),
+///         ("id" = u64, Path, description = "Pet database id to get Pet for"),
 ///     )
 /// )]
 /// async fn get_pet_by_id(pet_id: u64) -> Pet {
@@ -472,7 +472,7 @@ pub trait Modify {
     fn modify(&self, openapi: &mut openapi::OpenApi);
 }
 
-/// Trait used to convert implementing type to OpenAPI parameters for **actix-web** framework.
+/// Trait used to convert implementing type to OpenAPI parameters.
 ///
 /// This trait is [derivable][derive] for structs which are used to describe `path` or `query` parameters.
 /// For more details of `#[derive(IntoParams)]` refer to [derive documentation][derive].
@@ -482,7 +482,7 @@ pub trait Modify {
 /// Derive [`IntoParams`] implementation. This example will fail to compile because [`IntoParams`] cannot
 /// be used alone and it need to be used together with endpoint using the params as well. See
 /// [derive documentation][derive] for more details.
-/// ```compile_fail
+/// ```
 /// use utoipa::{IntoParams};
 ///
 /// #[derive(IntoParams)]
@@ -503,12 +503,14 @@ pub trait Modify {
 /// #    name: String,
 /// # }
 /// impl utoipa::IntoParams for PetParams {
-///     fn into_params() -> Vec<utoipa::openapi::path::Parameter> {
+///     fn into_params(
+///         parameter_in_provider: impl Fn() -> Option<utoipa::openapi::path::ParameterIn>
+///     ) -> Vec<utoipa::openapi::path::Parameter> {
 ///         vec![
 ///             utoipa::openapi::path::ParameterBuilder::new()
 ///                 .name("id")
 ///                 .required(utoipa::openapi::Required::True)
-///                 .parameter_in(utoipa::openapi::path::ParameterIn::Path)
+///                 .parameter_in(parameter_in_provider().unwrap_or_default())
 ///                 .description(Some("Id of pet"))
 ///                 .schema(Some(
 ///                     utoipa::openapi::PropertyBuilder::new()
@@ -519,7 +521,7 @@ pub trait Modify {
 ///             utoipa::openapi::path::ParameterBuilder::new()
 ///                 .name("name")
 ///                 .required(utoipa::openapi::Required::True)
-///                 .parameter_in(utoipa::openapi::path::ParameterIn::Path)
+///                 .parameter_in(parameter_in_provider().unwrap_or_default())
 ///                 .description(Some("Name of pet"))
 ///                 .schema(Some(
 ///                     utoipa::openapi::PropertyBuilder::new()
@@ -531,7 +533,6 @@ pub trait Modify {
 /// }
 /// ```
 /// [derive]: derive.IntoParams.html
-#[cfg(feature = "actix_extras")]
 pub trait IntoParams {
     /// Provide [`Vec`] of [`openapi::path::Parameter`]s to caller. The result is used in `utoipa-gen` library to
     /// provide OpenAPI parameter information for the endpoint using the parameters.

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -396,10 +396,18 @@ macro_rules! builder {
         #[doc = concat!("Builder for [`", stringify!($name),
             "`] with chainable configuration methods to create a new [`", stringify!($name) , "`].")]
         $( #[$builder_meta] )*
-        #[derive(Default)]
         #[cfg_attr(feature = "debug", derive(Debug))]
         $vis $key $builder_name {
             $( $field: $field_ty, )*
+        }
+
+        impl Default for $builder_name {
+            fn default() -> Self {
+                let meta_default: $name = $name::default();
+                Self {
+                    $( $field: meta_default.$field, )*
+                }
+            }
         }
 
         impl $builder_name {

--- a/src/openapi/schema.rs
+++ b/src/openapi/schema.rs
@@ -654,7 +654,7 @@ builder! {
     ///
     /// See [`Component::Array`] for more details.
     #[non_exhaustive]
-    #[derive(Serialize, Deserialize, Default, Clone)]
+    #[derive(Serialize, Deserialize, Clone)]
     #[cfg_attr(feature = "debug", derive(Debug))]
     #[serde(rename_all = "camelCase")]
     pub struct Array {
@@ -679,6 +679,18 @@ builder! {
     }
 }
 
+impl Default for Array {
+    fn default() -> Self {
+        Self {
+            component_type: ComponentType::Array,
+            items: Default::default(),
+            max_items: Default::default(),
+            min_items: Default::default(),
+            xml: Default::default(),
+        }
+    }
+}
+
 impl Array {
     /// Construct a new [`Array`] component from given [`Component`].
     ///
@@ -691,7 +703,6 @@ impl Array {
     /// ```
     pub fn new<I: Into<Component>>(component: I) -> Self {
         Self {
-            component_type: ComponentType::Array,
             items: Box::new(component.into()),
             ..Default::default()
         }

--- a/src/openapi/schema.rs
+++ b/src/openapi/schema.rs
@@ -946,4 +946,38 @@ mod tests {
             acc.get(fragment).unwrap_or(&serde_json::value::Value::Null)
         })
     }
+
+    #[test]
+    fn test_array_new() {
+        let array = Array::new(
+            ObjectBuilder::new().property(
+                "id",
+                PropertyBuilder::new()
+                    .component_type(ComponentType::Integer)
+                    .format(Some(ComponentFormat::Int32))
+                    .description(Some("Id of credential"))
+                    .default(Some(json!(1i32))),
+            ),
+        );
+
+        assert!(matches!(array.component_type, ComponentType::Array));
+    }
+
+    #[test]
+    fn test_array_builder() {
+        let array: Array = ArrayBuilder::new()
+            .items(
+                ObjectBuilder::new().property(
+                    "id",
+                    PropertyBuilder::new()
+                        .component_type(ComponentType::Integer)
+                        .format(Some(ComponentFormat::Int32))
+                        .description(Some("Id of credential"))
+                        .default(Some(json!(1i32))),
+                ),
+            )
+            .build();
+
+        assert!(matches!(array.component_type, ComponentType::Array));
+    }
 }

--- a/src/openapi/security.rs
+++ b/src/openapi/security.rs
@@ -187,7 +187,7 @@ builder! {
     ///
     /// Methods can be chained to configure _bearer_format_ or to add _description_.
     #[non_exhaustive]
-    #[derive(Serialize, Deserialize, Clone)]
+    #[derive(Serialize, Deserialize, Clone, Default)]
     #[serde(rename_all = "camelCase")]
     #[cfg_attr(feature = "debug", derive(Debug))]
     pub struct Http {

--- a/tests/component_derive_test.rs
+++ b/tests/component_derive_test.rs
@@ -596,6 +596,38 @@ fn derive_simple_enum_serde_tag() {
 
 /// Derive a complex enum with named and unnamed fields.
 #[test]
+fn derive_complex_unnamed_field_reference_with_comment() {
+    #[derive(Serialize)]
+    struct CommentedReference(String);
+
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        enum EnumWithReference {
+            /// This is comment which will not be added to the document
+            /// since $ref cannot have comments
+            UnnamedFieldWithCommentReference(CommentedReference),
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "UnnamedFieldWithCommentReference": {
+                            "$ref": "#/components/schemas/CommentedReference",
+                        },
+                    },
+                },
+            ],
+        })
+    );
+}
+
+/// Derive a complex enum with named and unnamed fields.
+#[test]
 fn derive_complex_enum() {
     #[derive(Serialize)]
     struct Foo(String);

--- a/tests/component_derive_test.rs
+++ b/tests/component_derive_test.rs
@@ -1092,6 +1092,57 @@ fn derive_unnamed_struct_component_type_override_with_format() {
     }
 }
 
+#[test]
+fn derive_struct_override_type_with_any_type() {
+    let value = api_doc! {
+        struct Value {
+            #[component(value_type = Any)]
+            field: String,
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "type": "object",
+            "properties": {
+                "field": {
+                    "type": "object"
+                }
+            },
+            "required": ["field"]
+        })
+    )
+}
+
+#[test]
+fn derive_struct_override_type_with_a_reference() {
+    mod custom {
+        #[allow(dead_code)]
+        struct NewBar;
+    }
+
+    let value = api_doc! {
+        struct Value {
+            #[component(value_type = custom::NewBar)]
+            field: String,
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "type": "object",
+            "properties": {
+                "field": {
+                    "$ref": "#/components/schemas/NewBar"
+                }
+            },
+            "required": ["field"]
+        })
+    )
+}
+
 #[cfg(feature = "decimal")]
 #[test]
 fn derive_struct_with_rust_decimal() {

--- a/tests/component_derive_test.rs
+++ b/tests/component_derive_test.rs
@@ -508,6 +508,71 @@ fn derive_with_box_and_refcell() {
 }
 
 #[test]
+fn derive_with_inline() {
+    #[derive(utoipa::Component)]
+    #[allow(unused)]
+    struct Foo {
+        name: &'static str,
+    }
+
+    let greeting = api_doc! {
+        struct Greeting {
+            #[component(inline)]
+            foo1: Foo,
+            #[component(inline)]
+            foo2: Option<Foo>,
+            #[component(inline)]
+            foo3: Option<Box<Foo>>,
+        }
+    };
+
+    assert_json_eq!(
+        &greeting,
+        json!({
+            "properties": {
+                "foo1": {
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                    },
+                    "required": [
+                        "name"
+                    ],
+                    "type": "object"
+                },
+                "foo2": {
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                    },
+                    "required": [
+                        "name"
+                    ],
+                    "type": "object"
+                },
+                "foo3": {
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                    },
+                    "required": [
+                        "name"
+                    ],
+                    "type": "object"
+                },
+            },
+            "required": [
+                "foo1"
+            ],
+            "type": "object"
+        })
+    );
+}
+
+#[test]
 fn derive_simple_enum() {
     let value: Value = api_doc! {
         #[derive(Serialize)]

--- a/tests/component_derive_test.rs
+++ b/tests/component_derive_test.rs
@@ -139,7 +139,7 @@ fn derive_struct_with_custom_properties_success() {
             #[component(
                 default = "testhash",
                 example = "base64 text",
-                format = ComponentFormat::Byte,
+                format = Byte,
             )]
             hash: String,
         }
@@ -1035,7 +1035,7 @@ fn derive_struct_component_field_type_override_with_format() {
     let post = api_doc! {
         struct Post {
             id: i32,
-            #[component(value_type = String, format = ComponentFormat::Byte)]
+            #[component(value_type = String, format = Byte)]
             value: i64,
         }
     };
@@ -1053,7 +1053,7 @@ fn derive_struct_component_field_type_override_with_format_with_vec() {
     let post = api_doc! {
         struct Post {
             id: i32,
-            #[component(value_type = String, format = ComponentFormat::Binary)]
+            #[component(value_type = String, format = Binary)]
             value: Vec<u8>,
         }
     };
@@ -1082,7 +1082,7 @@ fn derive_unnamed_struct_component_type_override() {
 #[test]
 fn derive_unnamed_struct_component_type_override_with_format() {
     let value = api_doc! {
-        #[component(value_type = String, format = ComponentFormat::Byte)]
+        #[component(value_type = String, format = Byte)]
         struct Value(i64);
     };
 

--- a/tests/path_derive.rs
+++ b/tests/path_derive.rs
@@ -410,6 +410,10 @@ fn derive_path_params_intoparams() {
         #[param(inline)]
         #[allow(unused)]
         foo_inline: Foo,
+        /// An optional Foo item inline.
+        #[param(inline)]
+        #[allow(unused)]
+        foo_inline_option: Option<Foo>,
     }
 
     #[utoipa::path(
@@ -482,6 +486,19 @@ fn derive_path_params_intoparams() {
                 "in": "query",
                 "name": "foo_inline",
                 "required": true,
+                "schema": {
+                    "default": "foo1",
+                    "example": "foo1",
+                    "enum": ["foo1", "foo2"],
+                    "type": "string",
+                },
+                "style": "form"
+            },
+            {
+                "description": "An optional Foo item inline.",
+                "in": "query",
+                "name": "foo_inline_option",
+                "required": false,
                 "schema": {
                     "default": "foo1",
                     "example": "foo1",

--- a/tests/path_derive.rs
+++ b/tests/path_derive.rs
@@ -2,7 +2,7 @@
 use assert_json_diff::assert_json_eq;
 use paste::paste;
 use serde_json::{json, Value};
-use utoipa::IntoParams;
+use utoipa::{Component, IntoParams};
 
 mod common;
 
@@ -384,6 +384,14 @@ fn derive_path_with_parameter_inline_schema() {
 
 #[test]
 fn derive_path_params_intoparams() {
+    #[derive(serde::Deserialize, Component)]
+    #[component(default = "foo1", example = "foo1")]
+    #[serde(rename_all = "snake_case")]
+    enum Foo {
+        Foo1,
+        Foo2,
+    }
+
     #[derive(serde::Deserialize, IntoParams)]
     #[into_params(style = Form, parameter_in = Query)]
     struct MyParams {
@@ -395,6 +403,13 @@ fn derive_path_params_intoparams() {
         #[param(example = "2020-04-12T10:23:00Z")]
         #[allow(unused)]
         since: Option<String>,
+        /// A Foo item ref.
+        #[allow(unused)]
+        foo_ref: Foo,
+        /// A Foo item inline.
+        #[param(inline)]
+        #[allow(unused)]
+        foo_inline: Foo,
     }
 
     #[utoipa::path(
@@ -449,6 +464,29 @@ fn derive_path_params_intoparams() {
                 "required": false,
                 "schema": {
                     "type": "string"
+                },
+                "style": "form"
+            },
+            {
+                "description": "A Foo item ref.",
+                "in": "query",
+                "name": "foo_ref",
+                "required": true,
+                "schema": {
+                    "$ref": "#/components/schemas/Foo"
+                },
+                "style": "form"
+            },
+            {
+                "description": "A Foo item inline.",
+                "in": "query",
+                "name": "foo_inline",
+                "required": true,
+                "schema": {
+                    "default": "foo1",
+                    "example": "foo1",
+                    "enum": ["foo1", "foo2"],
+                    "type": "string",
                 },
                 "style": "form"
             },

--- a/tests/path_derive.rs
+++ b/tests/path_derive.rs
@@ -257,7 +257,7 @@ fn derive_path_with_parameter_schema() {
         ),
         params(
             ("id" = u64, description = "Foo database id"),
-            ("since" = Option<Since>, query, description = "Datetime since foo is updated")
+            ("since" = Option<Since>, Query, description = "Datetime since foo is updated")
         )
     )]
     #[allow(unused)]
@@ -324,7 +324,7 @@ fn derive_path_with_parameter_inline_schema() {
         ),
         params(
             ("id" = u64, description = "Foo database id"),
-            ("since" = inline(Option<Since>), query, description = "Datetime since foo is updated")
+            ("since" = inline(Option<Since>), Query, description = "Datetime since foo is updated")
         )
     )]
     #[allow(unused)]

--- a/tests/path_parameter_derive_test.rs
+++ b/tests/path_parameter_derive_test.rs
@@ -16,7 +16,7 @@ mod derive_params_all_options {
             (status = 200, description = "success"),
         ),
         params(
-            ("id" = i32, path, deprecated, description = "Search foos by ids"),
+            ("id" = i32, Path, deprecated, description = "Search foos by ids"),
         )
     )]
     #[allow(unused)]
@@ -148,11 +148,11 @@ mod mod_derive_parameters_all_types {
             (status = 200, description = "success"),
         ),
         params(
-            ("id" = i32, path, description = "Foo id"),
-            ("since" = String, deprecated, query, description = "Datetime since"),
-            ("numbers" = Option<[u64]>, query, description = "Foo numbers list"),
-            ("token" = String, header, deprecated, description = "Token of foo"),
-            ("cookieval" = String, cookie, deprecated, description = "Foo cookie"),
+            ("id" = i32, Path, description = "Foo id"),
+            ("since" = String, deprecated, Query, description = "Datetime since"),
+            ("numbers" = Option<[u64]>, Query, description = "Foo numbers list"),
+            ("token" = String, Header, deprecated, description = "Token of foo"),
+            ("cookieval" = String, Cookie, deprecated, description = "Foo cookie"),
         )
     )]
     #[allow(unused)]
@@ -224,7 +224,7 @@ mod derive_params_without_args {
             (status = 200, description = "success"),
         ),
         params(
-            ("id" = i32, path, description = "Foo id"),
+            ("id" = i32, Path, description = "Foo id"),
         )
     )]
     #[allow(unused)]
@@ -263,7 +263,7 @@ fn derive_params_with_params_ext() {
             (status = 200, description = "success"),
         ),
         params(
-            ("value" = Option<[String]>, query, description = "Foo value description", style = Form, allow_reserved, deprecated, explode)
+            ("value" = Option<[String]>, Query, description = "Foo value description", style = Form, allow_reserved, deprecated, explode)
         )
     )]
     #[allow(unused)]

--- a/tests/path_response_derive_test.rs
+++ b/tests/path_response_derive_test.rs
@@ -221,7 +221,7 @@ fn derive_reponse_multiple_content_types() {
 }
 
 #[test]
-fn derive_response_body_inline_schema() {
+fn derive_response_body_inline_schema_component() {
     test_fn! {
         module: response_body_inline_schema,
         responses: (
@@ -262,6 +262,4 @@ fn derive_response_body_inline_schema() {
             ]
         })
     );
-
-    // panic!("{}", serde_json::to_string_pretty(&doc).unwrap())
 }

--- a/tests/request_body_derive_test.rs
+++ b/tests/request_body_derive_test.rs
@@ -290,8 +290,6 @@ fn derive_request_body_complex_success_inline_array() {
             "required": true
         })
     );
-
-    // panic!("{}", serde_json::to_string_pretty(&request_body).unwrap());
 }
 
 test_fn! {

--- a/tests/request_body_derive_test.rs
+++ b/tests/request_body_derive_test.rs
@@ -169,8 +169,6 @@ fn derive_request_body_complex_success() {
             "required": true
         })
     );
-
-    // panic!("{}", serde_json::to_string_pretty(&request_body).unwrap());
 }
 
 test_fn! {

--- a/tests/request_body_derive_test.rs
+++ b/tests/request_body_derive_test.rs
@@ -12,13 +12,13 @@ macro_rules! test_fn {
                 name: String,
             }
             #[utoipa::path(
-                                                post,
-                                                path = "/foo",
-                                                request_body $($body)*,
-                                                responses(
-                                                    (status = 200, description = "success response")
-                                                )
-                                            )]
+                post,
+                path = "/foo",
+                request_body $($body)*,
+                responses(
+                    (status = 200, description = "success response")
+                )
+            )]
             fn post_foo() {}
         }
     };

--- a/tests/request_body_derive_test.rs
+++ b/tests/request_body_derive_test.rs
@@ -1,4 +1,6 @@
 #![cfg(feature = "serde_json")]
+use assert_json_diff::assert_json_eq;
+use serde_json::{json, Value};
 use utoipa::OpenApi;
 
 mod common;
@@ -7,8 +9,10 @@ macro_rules! test_fn {
     ( module: $name:ident, body: $($body:tt)* ) => {
         #[allow(unused)]
         mod $name {
-
+            #[derive(utoipa::Component)]
+            /// Some struct
             struct Foo {
+                /// Some name
                 name: String,
             }
             #[utoipa::path(
@@ -149,14 +153,145 @@ fn derive_request_body_complex_success() {
 
     let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
 
-    assert_value! {doc=>
-        "paths./foo.post.requestBody.content.application/json" = r###"null"###, "Request body content object type not application/json"
-        "paths./foo.post.requestBody.content.text/xml.schema.$ref" = r###""#/components/schemas/Foo""###, "Request body content object type"
-        "paths./foo.post.requestBody.content.text/plain.schema.type" = r###"null"###, "Request body content object item type"
-        "paths./foo.post.requestBody.content.text/plain.schema.items.type" = r###"null"###, "Request body content items object type"
-        "paths./foo.post.requestBody.required" = r###"true"###, "Request body required"
-        "paths./foo.post.requestBody.description" = r###""Create new Foo""###, "Request body description"
-    }
+    let request_body: &Value = doc.pointer("/paths/~1foo/post/requestBody").unwrap();
+
+    assert_json_eq!(
+        request_body,
+        json!({
+            "content": {
+                "text/xml": {
+                    "schema": {
+                        "$ref": "#/components/schemas/Foo"
+                    }
+                }
+            },
+            "description": "Create new Foo",
+            "required": true
+        })
+    );
+
+    // panic!("{}", serde_json::to_string_pretty(&request_body).unwrap());
+}
+
+test_fn! {
+    module: derive_request_body_complex_inline,
+    body: (content = inline(Foo), description = "Create new Foo", content_type = "text/xml")
+}
+
+#[test]
+fn derive_request_body_complex_success_inline() {
+    #[derive(OpenApi, Default)]
+    #[openapi(handlers(derive_request_body_complex_inline::post_foo))]
+    struct ApiDoc;
+
+    let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
+
+    let request_body: &Value = doc.pointer("/paths/~1foo/post/requestBody").unwrap();
+
+    assert_json_eq!(
+        request_body,
+        json!({
+            "content": {
+                "text/xml": {
+                    "schema": {
+                        "description": "Some struct",
+                        "properties": {
+                            "name": {
+                                "description": "Some name",
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "name"
+                        ],
+                        "type": "object"
+                    }
+                }
+            },
+            "description": "Create new Foo",
+            "required": true
+        })
+    );
+}
+
+test_fn! {
+    module: derive_request_body_complex_array,
+    body: (content = [Foo], description = "Create new Foo", content_type = "text/xml")
+}
+
+#[test]
+fn derive_request_body_complex_success_array() {
+    #[derive(OpenApi, Default)]
+    #[openapi(handlers(derive_request_body_complex_array::post_foo))]
+    struct ApiDoc;
+
+    let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
+
+    let request_body: &Value = doc.pointer("/paths/~1foo/post/requestBody").unwrap();
+
+    assert_json_eq!(
+        request_body,
+        json!({
+            "content": {
+                "text/xml": {
+                    "schema": {
+                        "items": {
+                            "$ref": "#/components/schemas/Foo"
+                        },
+                        "type": "array"
+                    }
+                }
+            },
+            "description": "Create new Foo",
+            "required": true
+        })
+    );
+}
+
+test_fn! {
+    module: derive_request_body_complex_inline_array,
+    body: (content = inline([Foo]), description = "Create new Foo", content_type = "text/xml")
+}
+
+#[test]
+fn derive_request_body_complex_success_inline_array() {
+    #[derive(OpenApi, Default)]
+    #[openapi(handlers(derive_request_body_complex_inline_array::post_foo))]
+    struct ApiDoc;
+
+    let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
+
+    let request_body: &Value = doc.pointer("/paths/~1foo/post/requestBody").unwrap();
+
+    assert_json_eq!(
+        request_body,
+        json!({
+            "content": {
+                "text/xml": {
+                    "schema": {
+                        "items": {
+                            "description": "Some struct",
+                            "properties": {
+                                "name": {
+                                    "description": "Some name",
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "name"
+                            ],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    }
+                }
+            },
+            "description": "Create new Foo",
+            "required": true
+        })
+    );
+
+    // panic!("{}", serde_json::to_string_pretty(&request_body).unwrap());
 }
 
 test_fn! {

--- a/tests/utoipa_gen_test.rs
+++ b/tests/utoipa_gen_test.rs
@@ -58,7 +58,7 @@ mod pet_api {
             (status = 404, description = "Pet was not found")
         ),
         params(
-            ("id" = u64, path, description = "Pet database id to get Pet for"),
+            ("id" = u64, Path, description = "Pet database id to get Pet for"),
         ),
         security(
             (),

--- a/utoipa-gen/src/component_type.rs
+++ b/utoipa-gen/src/component_type.rs
@@ -3,6 +3,7 @@ use std::fmt::Display;
 use quote::{quote, ToTokens};
 
 /// Tokenizes OpenAPI data type correctly according to the Rust type
+// TODO: see if this can't be unified with crate::Type
 pub struct ComponentType<'a, T: Display>(pub &'a T);
 
 impl<'a, T> ComponentType<'a, T>

--- a/utoipa-gen/src/component_type.rs
+++ b/utoipa-gen/src/component_type.rs
@@ -3,7 +3,6 @@ use std::fmt::Display;
 use quote::{quote, ToTokens};
 
 /// Tokenizes OpenAPI data type correctly according to the Rust type
-// TODO: see if this can't be unified with crate::Type
 pub struct ComponentType<'a, T: Display>(pub &'a T);
 
 impl<'a, T> ComponentType<'a, T>

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -19,7 +19,7 @@ use proc_macro_error::{proc_macro_error, OptionExt, ResultExt};
 use quote::{quote, ToTokens, TokenStreamExt};
 use schema::into_params::IntoParams;
 
-use proc_macro2::{Group, Ident, Punct, Span, TokenStream as TokenStream2};
+use proc_macro2::{Group, Ident, Punct, TokenStream as TokenStream2};
 use syn::{
     bracketed,
     parse::{Parse, ParseBuffer, ParseStream},
@@ -1303,7 +1303,7 @@ impl Parse for Type<'_> {
             .parse::<ArrayOrOptionType>()
             .map_err(|error| {
                 syn::Error::new(
-                    Span::call_site(),
+                    error.span(),
                     format!("{}: {}", EXPECTED_TYPE_DEFINITION, error),
                 )
             })?

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -1092,6 +1092,8 @@ impl Parse for Type<'_> {
 
 /// A place where a type defenition is required. The type schema can either be a referenced
 /// component or provided inline.
+// TODO: perhaps this could be rolled into `Type` with a new is_inline function.
+#[derive(Clone)]
 enum TypeDefinition<'a> {
     Component(Type<'a>),
     Inline(Type<'a>),

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -91,6 +91,8 @@ use ext::ArgumentResolver;
 ///   This is useful in cases the where default type does not correspond to the actual type e.g. when
 ///   any third-party types are used which are not components nor primitive types. With **value_type** we can enforce
 ///   type used to certain type. Value type may only be [`primitive`][primitive] type or [`String`]. Generic types are not allowed.
+/// * `inline` If the type of this field implements [`Component`][c], then the schema definition
+///   will be inlined. **warning:** Don't use this for recursive data types!
 ///
 /// [^json2]: Values are converted to string if **json** feature is not enabled.
 ///
@@ -366,8 +368,8 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 /// # Request Body Attributes
 ///
 /// * `content = ...` Can be used to define the content object. Should be an identifier, slice or option
-///   E.g. _`Pet`_ or _`[Pet]`_ or _`Option<Pet>`_. Where the type implments [`Component`][component], 
-///   it can also be  wrapped in `inline(...)` in order to inline the component schema definition. 
+///   E.g. _`Pet`_ or _`[Pet]`_ or _`Option<Pet>`_. Where the type implments [`Component`][component],
+///   it can also be  wrapped in `inline(...)` in order to inline the component schema definition.
 ///   E.g. _`inline(Pet)`_.
 /// * `description = "..."` Define the description for the request body object as str.
 /// * `content_type = "..."` Can be used to override the default behavior of auto resolving the content type
@@ -392,7 +394,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 /// * `status = ...` Is valid http status code. E.g. _`200`_
 /// * `description = "..."` Define description for the response as str.
 /// * `body = ...` Optional response body object type. When left empty response does not expect to send any
-///   response body. Should be an identifier or slice. E.g _`Pet`_ or _`[Pet]`_. Where the type implments [`Component`][component], 
+///   response body. Should be an identifier or slice. E.g _`Pet`_ or _`[Pet]`_. Where the type implments [`Component`][component],
 ///   it can also be wrapped in `inline(...)` in order to inline the component schema definition. E.g. _`inline(Pet)`_.
 /// * `content_type = "..." | content_type = [...]` Can be used to override the default behavior of auto resolving the content type
 ///   from the `body` attribute. If defined the value should be valid content type such as
@@ -440,7 +442,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 /// # Params Attributes
 ///
 /// * `name` _**Must be the first argument**_. Define the name for parameter.
-/// * `parameter_type` Define possible type for the parameter. Type should be an identifier, slice `[Type]`, 
+/// * `parameter_type` Define possible type for the parameter. Type should be an identifier, slice `[Type]`,
 ///   option `Option<Type>`. Where the type implments [`Component`][component], it can also be wrapped in `inline(MyComponent)`
 ///   in order to inline the component schema definition.
 ///   E.g. _`String`_ or _`[String]`_ or _`Option<String>`_. Parameter type is placed after `name` with

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -71,7 +71,7 @@ use ext::ArgumentResolver;
 /// # Unnamed Field Struct Optional Configuration Options for `#[component(...)]`
 /// * `example = ...` Can be literal value, method reference or _`json!(...)`_. [^json2]
 /// * `default = ...` Can be literal value, method reference or _`json!(...)`_. [^json2]
-/// * `format = ...` [`ComponentFormat`][format] to use for the property. By default the format is derived from
+/// * `format = ...` Any variant of a [`ComponentFormat`][format] to use for the property. By default the format is derived from
 ///   the type of the property according OpenApi spec.
 /// * `value_type = ...` Can be used to override default type derived from type of the field used in OpenAPI spec.
 ///   This is useful in cases where the default type does not correspond to the actual type e.g. when
@@ -84,7 +84,7 @@ use ext::ArgumentResolver;
 /// # Named Fields Optional Configuration Options for `#[component(...)]`
 /// * `example = ...` Can be literal value, method reference or _`json!(...)`_. [^json2]
 /// * `default = ...` Can be literal value, method reference or _`json!(...)`_. [^json2]
-/// * `format = ...` [`ComponentFormat`][format] to use for the property. By default the format is derived from
+/// * `format = ...` Any variant of a [`ComponentFormat`][format] to use for the property. By default the format is derived from
 ///   the type of the property according OpenApi spec.
 /// * `write_only` Defines property is only used in **write** operations *POST,PUT,PATCH* but not in *GET*
 /// * `read_only` Defines property is only used in **read** operations *GET* but not in *POST,PUT,PATCH*
@@ -302,7 +302,7 @@ use ext::ArgumentResolver;
 /// #[derive(Component)]
 /// struct Post {
 ///     id: i32,
-///     #[component(value_type = String, format = ComponentFormat::Binary)]
+///     #[component(value_type = String, format = Binary)]
 ///     value: Vec<u8>,
 /// }
 /// ```

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -936,6 +936,8 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 /// * `allow_reserved` Defines whether reserved characters _`:/?#[]@!$&'()*+,;=`_ is allowed within value.
 /// * `example = ...` Can be literal value, method reference or _`json!(...)`_. [^json] Given example
 ///   will override any example in underlying parameter type.
+/// * `inline` If set, the schema for this field's type needs to be a [`Component`][component], and
+///   the component schema definition will be inlined.
 ///
 /// **Note!** `#[into_params(...)]` is only supported on unnamed struct types to declare names for the arguments.
 ///
@@ -995,10 +997,17 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 /// ```
 ///
 /// Demonstrate [`IntoParams`][into_params] usage with the `#[param(...)]` container attribute to
-/// be used as a path query:
+/// be used as a path query, and inlining a component query field:
 /// ```rust
 /// use serde::Deserialize;
-/// use utoipa::IntoParams;
+/// use utoipa::{IntoParams, Component};
+///
+/// #[derive(Deserialize, Component)]
+/// #[serde(rename_all = "snake_case")]
+/// enum PetKind {
+///     Dog,
+///     Cat,
+/// }
 ///
 /// #[derive(Deserialize, IntoParams)]
 /// #[param(style = Form, parameter_in = Query)]
@@ -1007,6 +1016,9 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 ///     name: Option<String>,
 ///     /// Age of pet
 ///     age: Option<i32>,
+///     /// Kind of pet
+///     #[param(inline)]
+///     kind: PetKind
 /// }
 ///
 /// #[utoipa::path(
@@ -1021,7 +1033,7 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 ///     // ...
 /// }
 /// ```
-///
+/// [component]: trait.Component.html
 /// [into_params]: trait.IntoParams.html
 /// [path_params]: attr.path.html#params-attributes
 /// [struct]: https://doc.rust-lang.org/std/keyword.struct.html

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -1044,6 +1044,7 @@ impl<'a> Type<'a> {
             ty: ident,
             is_array,
             is_option,
+            is_inline: false,
         }
     }
 }

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -366,7 +366,9 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 /// # Request Body Attributes
 ///
 /// * `content = ...` Can be used to define the content object. Should be an identifier, slice or option
-///   E.g. _`Pet`_ or _`[Pet]`_ or _`Option<Pet>`_.
+///   E.g. _`Pet`_ or _`[Pet]`_ or _`Option<Pet>`_. Where the type implments [`Component`][component], 
+///   it can also be  wrapped in `inline(...)` in order to inline the component schema definition. 
+///   E.g. _`inline(Pet)`_.
 /// * `description = "..."` Define the description for the request body object as str.
 /// * `content_type = "..."` Can be used to override the default behavior of auto resolving the content type
 ///   from the `content` attribute. If defined the value should be valid content type such as
@@ -390,7 +392,8 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 /// * `status = ...` Is valid http status code. E.g. _`200`_
 /// * `description = "..."` Define description for the response as str.
 /// * `body = ...` Optional response body object type. When left empty response does not expect to send any
-///   response body. Should be an identifier or slice. E.g _`Pet`_ or _`[Pet]`_
+///   response body. Should be an identifier or slice. E.g _`Pet`_ or _`[Pet]`_. Where the type implments [`Component`][component], 
+///   it can also be wrapped in `inline(...)` in order to inline the component schema definition. E.g. _`inline(Pet)`_.
 /// * `content_type = "..." | content_type = [...]` Can be used to override the default behavior of auto resolving the content type
 ///   from the `body` attribute. If defined the value should be valid content type such as
 ///   _`application/json`_. By default the content type is _`text/plain`_ for
@@ -437,7 +440,9 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 /// # Params Attributes
 ///
 /// * `name` _**Must be the first argument**_. Define the name for parameter.
-/// * `parameter_type` Define possible type for the parameter. Type should be an identifier, slice or option.
+/// * `parameter_type` Define possible type for the parameter. Type should be an identifier, slice `[Type]`, 
+///   option `Option<Type>`. Where the type implments [`Component`][component], it can also be wrapped in `inline(MyComponent)`
+///   in order to inline the component schema definition.
 ///   E.g. _`String`_ or _`[String]`_ or _`Option<String>`_. Parameter type is placed after `name` with
 ///   equals sign E.g. _`"id" = String`_
 /// * `in` _**Must be placed after name or parameter_type**_. Define the place of the parameter.
@@ -455,7 +460,16 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 /// ```text
 /// ("id" = String, path, deprecated, description = "Pet database id"),
 /// ("id", path, deprecated, description = "Pet database id"),
-/// ("value" = Option<[String]>, query, description = "Value description", style = Form, allow_reserved, deprecated, explode, example = json!(["Value"]))
+/// (
+///     "value" = inline(Option<[String]>),
+///     query,
+///     description = "Value description",
+///     style = Form,
+///     allow_reserved,
+///     deprecated,
+///     explode,
+///     example = json!(["Value"])
+/// )
 /// ```
 ///
 /// # Security Requirement Attributes
@@ -641,6 +655,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 /// }
 /// ```
 /// [path]: trait.Path.html
+/// [component]: trait.Component.html
 /// [openapi]: derive.OpenApi.html
 /// [security]: openapi/security/struct.SecurityRequirement.html
 /// [security_schema]: openapi/security/struct.SecuritySchema.html

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -1099,6 +1099,26 @@ enum TypeDefinition<'a> {
     Inline(Type<'a>),
 }
 
+impl Parse for TypeDefinition<'_> {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        const EXPECTED_TYPE_DEFINITION: &str =
+            "unexpected attribute, expected any of inline(Type), Type";
+        if input.fork().parse::<InlineType>().is_ok() {
+            let inline_type: InlineType = input.parse()?;
+            return Ok(Self::Inline(inline_type.0));
+        }
+
+        let t: Type = input.parse().map_err(|error| {
+            syn::Error::new(
+                Span::call_site(),
+                format!("{}: {}", EXPECTED_TYPE_DEFINITION, error),
+            )
+        })?;
+
+        Ok(Self::Component(t))
+    }
+}
+
 struct InlineType<'a>(Type<'a>);
 
 impl Parse for InlineType<'_> {
@@ -1127,26 +1147,6 @@ impl Parse for InlineType<'_> {
             }
             _ => Err(syn::Error::new(ident.span(), EXPECTED_TYPE_DEFINITION)),
         }
-    }
-}
-
-impl Parse for TypeDefinition<'_> {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
-        const EXPECTED_TYPE_DEFINITION: &str =
-            "unexpected attribute, expected any of inline(Type), Type";
-        if input.fork().parse::<InlineType>().is_ok() {
-            let inline_type: InlineType = input.parse()?;
-            return Ok(Self::Inline(inline_type.0));
-        }
-
-        let t: Type = input.parse().map_err(|error| {
-            syn::Error::new(
-                Span::call_site(),
-                format!("{}: {}", EXPECTED_TYPE_DEFINITION, error),
-            )
-        })?;
-
-        Ok(Self::Component(t))
     }
 }
 

--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -343,10 +343,10 @@ impl<'p> Path<'p> {
     }
 }
 
-impl ToTokens for Path<'_> {
+impl<'p> ToTokens for Path<'p> {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         let path_struct = format_ident!("{}{}", PATH_STRUCT_PREFIX, self.fn_name);
-        let operation_id = self
+        let operation_id: &String = self
             .path_attr
             .operation_id
             .as_ref()
@@ -411,7 +411,7 @@ impl ToTokens for Path<'_> {
             .map(|context_path| format!("{context_path}{path}"))
             .unwrap_or_else(|| path.to_string());
 
-        let operation = Operation {
+        let operation: Operation = Operation {
             deprecated: &self.deprecated,
             operation_id,
             summary: self
@@ -447,7 +447,7 @@ impl ToTokens for Path<'_> {
                     )
                 }
             }
-        })
+        });
     }
 }
 

--- a/utoipa-gen/src/path/parameter.rs
+++ b/utoipa-gen/src/path/parameter.rs
@@ -9,7 +9,7 @@ use syn::{
 
 #[cfg(any(feature = "actix_extras", feature = "rocket_extras"))]
 use crate::ext::{Argument, ArgumentIn};
-use crate::{parse_utils, AnyValue, Deprecated, Required, Type, TypeDefinition};
+use crate::{parse_utils, AnyValue, Deprecated, Required, Type};
 
 use super::property::Property;
 
@@ -186,7 +186,7 @@ impl ToTokens for Parameter<'_> {
             }
 
             if let Some(parameter_type) = &parameter.parameter_type {
-                let property = Property::new(TypeDefinition::Component(parameter_type.clone()));
+                let property = Property::new(parameter_type.clone());
                 let required: Required = (!parameter_type.is_option).into();
 
                 tokens.extend(quote! { .schema(Some(#property)).required(#required) });

--- a/utoipa-gen/src/path/parameter.rs
+++ b/utoipa-gen/src/path/parameter.rs
@@ -203,7 +203,6 @@ impl ToTokens for ParameterValue<'_> {
                 tokens.extend(quote! { .explode(Some(#explode)) });
             }
 
-
             if let Some(ref allow_reserved) = ext.allow_reserved {
                 tokens.extend(quote! { .allow_reserved(Some(#allow_reserved)) });
             }

--- a/utoipa-gen/src/path/parameter.rs
+++ b/utoipa-gen/src/path/parameter.rs
@@ -9,7 +9,7 @@ use syn::{
 
 #[cfg(any(feature = "actix_extras", feature = "rocket_extras"))]
 use crate::ext::{Argument, ArgumentIn};
-use crate::{parse_utils, AnyValue, Deprecated, Required, Type};
+use crate::{parse_utils, AnyValue, Deprecated, Required, Type, TypeDefinition};
 
 use super::property::Property;
 
@@ -185,8 +185,8 @@ impl ToTokens for Parameter<'_> {
                 }
             }
 
-            if let Some(ref parameter_type) = parameter.parameter_type {
-                let property = Property::new(parameter_type.is_array, &parameter_type.ty);
+            if let Some(parameter_type) = &parameter.parameter_type {
+                let property = Property::new(TypeDefinition::Component(parameter_type.clone()));
                 let required: Required = (!parameter_type.is_option).into();
 
                 tokens.extend(quote! { .schema(Some(#property)).required(#required) });

--- a/utoipa-gen/src/path/parameter.rs
+++ b/utoipa-gen/src/path/parameter.rs
@@ -213,7 +213,7 @@ impl ToTokens for ParameterValue<'_> {
             }
         }
 
-        if let Some(parameter_type) = &parameter.parameter_type {
+        if let Some(parameter_type) = &self.parameter_type {
             let property = Property::new(parameter_type.clone());
             let required: Required = (!parameter_type.is_option).into();
 

--- a/utoipa-gen/src/path/parameter.rs
+++ b/utoipa-gen/src/path/parameter.rs
@@ -313,6 +313,7 @@ pub struct ParameterExt {
     pub style: Option<ParameterStyle>,
     pub explode: Option<bool>,
     pub allow_reserved: Option<bool>,
+    pub inline: Option<bool>,
     pub(crate) example: Option<AnyValue>,
 }
 
@@ -339,11 +340,14 @@ impl ParameterExt {
         if from.example.is_some() {
             self.example = from.example
         }
+        if from.inline.is_some() {
+            self.inline = from.inline
+        }
     }
 
     fn parse_once(input: ParseStream) -> syn::Result<Self> {
         const EXPECTED_ATTRIBUTE_MESSAGE: &str =
-            "unexpected attribute, expected any of: style, explode, allow_reserved, example";
+            "unexpected attribute, expected any of: style, explode, allow_reserved, example, inline";
 
         let ident = input.parse::<Ident>().map_err(|error| {
             Error::new(
@@ -372,6 +376,10 @@ impl ParameterExt {
                 example: Some(parse_utils::parse_next(input, || {
                     AnyValue::parse_any(input)
                 })?),
+                ..Default::default()
+            },
+            "inline" => ParameterExt {
+                inline: Some(parse_utils::parse_bool_or_true(input)?),
                 ..Default::default()
             },
             _ => return Err(Error::new(ident.span(), EXPECTED_ATTRIBUTE_MESSAGE)),

--- a/utoipa-gen/src/path/property.rs
+++ b/utoipa-gen/src/path/property.rs
@@ -52,9 +52,20 @@ impl ToTokens for Property<'_> {
             let name = component_name_ident.to_string();
 
             if self.type_definition.is_inline {
-                tokens.extend(quote! {
+                let component = quote! {
                     <#component_name_ident as utoipa::Component>::component()
-                })
+                };
+
+                if self.type_definition.is_array {
+                    let array_component = quote! {
+                        utoipa::openapi::schema::ArrayBuilder::new()
+                            .items(#component)
+                    };
+
+                    tokens.extend(array_component);
+                } else {
+                    tokens.extend(component);
+                }
             } else {
                 tokens.extend(quote! {
                     utoipa::openapi::Ref::from_component_name(#name)

--- a/utoipa-gen/src/path/property.rs
+++ b/utoipa-gen/src/path/property.rs
@@ -1,59 +1,68 @@
-use std::fmt::Display;
+use std::borrow::Cow;
 
+use proc_macro2::Ident;
 use quote::{quote, ToTokens};
 
-use crate::component_type::{ComponentFormat, ComponentType};
+use crate::{
+    component_type::{ComponentFormat, ComponentType},
+    TypeDefinition,
+};
 
 /// Tokenizable object property. It is used as a object property for components or as property
 /// of request or response body or response header.
-pub(crate) struct Property<'a, T: Display> {
-    pub(crate) is_array: bool,
-    pub(crate) component_type: ComponentType<'a, T>,
+// TODO: Switch this to support either references or inline definition.
+// file:///home/luke/programming/rust/utoipa/target/doc/utoipa/openapi/schema/enum.Component.html
+pub(crate) struct Property<'a> {
+    type_definition: TypeDefinition<'a>,
 }
 
-impl<'a, T> Property<'a, T>
-where
-    T: Display,
-{
-    pub fn new(is_array: bool, ident: &'a T) -> Self {
-        Self {
-            is_array,
-            component_type: ComponentType(ident),
-        }
+impl<'a> Property<'a> {
+    pub fn new(type_definition: TypeDefinition<'a>) -> Self {
+        Self { type_definition }
+    }
+
+    pub fn component_type(&self) -> ComponentType<'a, Cow<Ident>> {
+        let t = match &self.type_definition {
+            TypeDefinition::Component(t) => t,
+            TypeDefinition::Inline(t) => t,
+        };
+        ComponentType(&t.ty)
     }
 }
 
-impl<T> ToTokens for Property<'_, T>
-where
-    T: Display,
-{
+impl ToTokens for Property<'_> {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        if self.component_type.is_primitive() {
-            let component_type = &self.component_type;
-            let mut component = quote! {
-                utoipa::openapi::PropertyBuilder::new().component_type(#component_type)
-            };
+        match &self.type_definition {
+            TypeDefinition::Component(component_type_definition) => {
+                let component_type = ComponentType(&component_type_definition.ty);
+                if component_type.is_primitive() {
+                    let mut component = quote! {
+                        utoipa::openapi::PropertyBuilder::new().component_type(#component_type)
+                    };
 
-            let format = ComponentFormat(self.component_type.0);
-            if format.is_known_format() {
-                component.extend(quote! {
-                    .format(Some(#format))
-                })
+                    let format = ComponentFormat(component_type.0);
+                    if format.is_known_format() {
+                        component.extend(quote! {
+                            .format(Some(#format))
+                        })
+                    }
+
+                    tokens.extend(component);
+                } else {
+                    let name = &*component_type.0.to_string();
+
+                    tokens.extend(quote! {
+                        utoipa::openapi::Ref::from_component_name(#name)
+                    })
+                };
+
+                if component_type_definition.is_array {
+                    tokens.extend(quote! {
+                        .to_array_builder()
+                    });
+                }
             }
-
-            tokens.extend(component);
-        } else {
-            let name = &*self.component_type.0.to_string();
-
-            tokens.extend(quote! {
-                utoipa::openapi::Ref::from_component_name(#name)
-            })
-        };
-
-        if self.is_array {
-            tokens.extend(quote! {
-                .to_array_builder()
-            });
+            TypeDefinition::Inline(_) => todo!(),
         }
     }
 }

--- a/utoipa-gen/src/path/property.rs
+++ b/utoipa-gen/src/path/property.rs
@@ -10,8 +10,6 @@ use crate::{
 
 /// Tokenizable object property. It is used as a object property for components or as property
 /// of request or response body or response header.
-// TODO: Switch this to support either references or inline definition.
-// file:///home/luke/programming/rust/utoipa/target/doc/utoipa/openapi/schema/enum.Component.html
 pub(crate) struct Property<'a> {
     type_definition: TypeDefinition<'a>,
 }

--- a/utoipa-gen/src/path/request_body.rs
+++ b/utoipa-gen/src/path/request_body.rs
@@ -2,7 +2,7 @@ use proc_macro2::{Ident, TokenStream as TokenStream2};
 use quote::{quote, ToTokens};
 use syn::{parenthesized, parse::Parse, token::Paren, Error, Token};
 
-use crate::{parse_utils, Required, Type, TypeDefinition};
+use crate::{parse_utils, Required, Type};
 
 use super::{property::Property, ContentTypeResolver};
 
@@ -123,7 +123,7 @@ impl ContentTypeResolver for RequestBodyAttr<'_> {}
 impl ToTokens for RequestBodyAttr<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream2) {
         if let Some(body_type) = &self.content {
-            let property = Property::new(TypeDefinition::Component(body_type.clone()));
+            let property = Property::new(body_type.clone());
 
             let content_type =
                 self.resolve_content_type(self.content_type.as_ref(), &property.component_type());

--- a/utoipa-gen/src/path/request_body.rs
+++ b/utoipa-gen/src/path/request_body.rs
@@ -2,7 +2,7 @@ use proc_macro2::{Ident, TokenStream as TokenStream2};
 use quote::{quote, ToTokens};
 use syn::{parenthesized, parse::Parse, token::Paren, Error, Token};
 
-use crate::{parse_utils, Required, Type};
+use crate::{parse_utils, Required, Type, TypeDefinition};
 
 use super::{property::Property, ContentTypeResolver};
 
@@ -122,11 +122,11 @@ impl ContentTypeResolver for RequestBodyAttr<'_> {}
 
 impl ToTokens for RequestBodyAttr<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream2) {
-        if let Some(ref body_type) = self.content {
-            let property = Property::new(body_type.is_array, &body_type.ty);
+        if let Some(body_type) = &self.content {
+            let property = Property::new(TypeDefinition::Component(body_type.clone()));
 
             let content_type =
-                self.resolve_content_type(self.content_type.as_ref(), &property.component_type);
+                self.resolve_content_type(self.content_type.as_ref(), &property.component_type());
             let required: Required = (!body_type.is_option).into();
 
             tokens.extend(quote! {

--- a/utoipa-gen/src/path/response.rs
+++ b/utoipa-gen/src/path/response.rs
@@ -102,36 +102,29 @@ impl ToTokens for Response<'_> {
         });
 
         if let Some(response_type) = &self.response_type {
-            match response_type {
-                TypeDefinition::Component(body_type) => {
-                    let property = Property::new(TypeDefinition::Component(body_type.clone()));
-                    let mut content = quote! {
-                        utoipa::openapi::ContentBuilder::new().schema(#property)
-                    };
+            let property = Property::new(response_type.clone());
 
-                    if let Some(ref example) = self.example {
-                        content.extend(quote! {
-                            .example(Some(#example))
-                        })
-                    }
+            let mut content = quote! {
+                utoipa::openapi::ContentBuilder::new().schema(#property)
+            };
 
-                    if let Some(content_types) = self.content_type.as_ref() {
-                        content_types.iter().for_each(|content_type| {
-                            tokens.extend(quote! {
-                                .content(#content_type, #content.build())
-                            })
-                        })
-                    } else {
-                        let default_type =
-                            self.resolve_content_type(None, &property.component_type());
-                        tokens.extend(quote! {
-                            .content(#default_type, #content.build())
-                        });
-                    }
-                }
-                TypeDefinition::Inline(_body_type) => {
-                    todo!()
-                }
+            if let Some(ref example) = self.example {
+                content.extend(quote! {
+                    .example(Some(#example))
+                })
+            }
+
+            if let Some(content_types) = self.content_type.as_ref() {
+                content_types.iter().for_each(|content_type| {
+                    tokens.extend(quote! {
+                        .content(#content_type, #content.build())
+                    })
+                })
+            } else {
+                let default_type = self.resolve_content_type(None, &property.component_type());
+                tokens.extend(quote! {
+                    .content(#default_type, #content.build())
+                });
             }
         }
 

--- a/utoipa-gen/src/schema.rs
+++ b/utoipa-gen/src/schema.rs
@@ -182,6 +182,12 @@ impl<'a> ComponentPart<'a> {
     fn update_ident(&mut self, ident: &'a Ident) {
         self.ident = ident
     }
+
+    /// `Any` virtual type is used when generic object is required in OpenAPI spec. Typically used
+    /// with `value_override` attribute to hinder the actual type.
+    fn is_any(&self) -> bool {
+        &*self.ident == "Any"
+    }
 }
 
 impl<'a> AsMut<ComponentPart<'a>> for ComponentPart<'a> {

--- a/utoipa-gen/src/schema.rs
+++ b/utoipa-gen/src/schema.rs
@@ -7,7 +7,6 @@ use syn::{
 
 use crate::{component_type::ComponentType, Deprecated};
 
-#[cfg(feature = "actix_extras")]
 pub mod into_params;
 
 pub mod component;

--- a/utoipa-gen/src/schema/component.rs
+++ b/utoipa-gen/src/schema/component.rs
@@ -806,7 +806,7 @@ where
                                     <#component_name_ident as utoipa::Component>::component()
                                 });
                             } else {
-                                let name = &*self.component_part.ident.to_string();
+                                let name = &component_part.ident.to_string();
                                 tokens.extend(quote! {
                                     utoipa::openapi::Ref::from_component_name(#name)
                                 })

--- a/utoipa-gen/src/schema/component/attr.rs
+++ b/utoipa-gen/src/schema/component/attr.rs
@@ -12,7 +12,7 @@ use syn::{
 use crate::{
     parse_utils,
     schema::{ComponentPart, GenericType},
-    AnyValue,
+    AnyValue, ValueType,
 };
 
 use super::xml::{Xml, XmlAttr};
@@ -51,7 +51,7 @@ pub struct Struct {
 #[derive(Default)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct UnnamedFieldStruct {
-    pub(super) ty: Option<Ident>,
+    pub(super) value_type: Option<ValueType>,
     format: Option<ExprPath>,
     default: Option<AnyValue>,
     example: Option<AnyValue>,
@@ -61,7 +61,7 @@ pub struct UnnamedFieldStruct {
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct NamedField {
     example: Option<AnyValue>,
-    pub(super) ty: Option<Ident>,
+    pub(super) value_type: Option<ValueType>,
     format: Option<ExprPath>,
     default: Option<AnyValue>,
     write_only: Option<bool>,
@@ -192,8 +192,9 @@ impl Parse for ComponentAttr<UnnamedFieldStruct> {
                 }
                 "format" => unnamed_struct.format = Some(parse_format(input)?),
                 "value_type" => {
-                    unnamed_struct.ty =
-                        Some(parse_utils::parse_next(input, || input.parse::<Ident>())?)
+                    unnamed_struct.value_type = Some(parse_utils::parse_next(input, || {
+                        input.parse::<ValueType>()
+                    })?)
                 }
                 _ => return Err(Error::new(attribute.span(), EXPECTED_ATTRIBUTE_MESSAGE)),
             }
@@ -296,7 +297,9 @@ impl Parse for ComponentAttr<NamedField> {
                     field.xml_attr = Some(xml.parse()?)
                 }
                 "value_type" => {
-                    field.ty = Some(parse_utils::parse_next(input, || input.parse::<Ident>())?)
+                    field.value_type = Some(parse_utils::parse_next(input, || {
+                        input.parse::<ValueType>()
+                    })?)
                 }
                 _ => return Err(Error::new(ident.span(), EXPECTED_ATTRIBUTE_MESSAGE)),
             }

--- a/utoipa-gen/src/schema/into_params.rs
+++ b/utoipa-gen/src/schema/into_params.rs
@@ -284,12 +284,14 @@ impl ToTokens for Param<'_> {
         let mut parameter_ext = ParameterExt::from(&self.container_attributes);
 
         // Apply the field attributes if they exist.
-        field
+        if let Some(p) = field
             .attrs
             .iter()
             .find(|attribute| attribute.path.is_ident("param"))
             .map(|attribute| attribute.parse_args::<ParameterExt>().unwrap_or_abort())
-            .map(|p| parameter_ext.merge(p));
+        {
+            parameter_ext.merge(p)
+        }
 
         if let Some(ref style) = parameter_ext.style {
             tokens.extend(quote! { .style(Some(#style)) });

--- a/utoipa-gen/src/schema/into_params.rs
+++ b/utoipa-gen/src/schema/into_params.rs
@@ -2,54 +2,109 @@ use proc_macro_error::{abort, ResultExt};
 use quote::{quote, ToTokens};
 use syn::{
     parse::Parse, punctuated::Punctuated, token::Comma, Attribute, Data, Error, Field, Generics,
-    Ident, LitStr,
+    Ident, LitStr, Token,
 };
 
 use crate::{
     component_type::{ComponentFormat, ComponentType},
     doc_comment::CommentAttributes,
     parse_utils,
-    path::parameter::ParameterExt,
+    path::parameter::{ParameterExt, ParameterIn, ParameterStyle},
     Array, Required,
 };
 
 use super::{ComponentPart, GenericType, ValueType};
 
+/// Container attribute `#[into_params(...)]`.
+#[derive(Default)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct IntoParamsAttr {
-    names: Vec<String>,
+    /// See [`ParameterStyle`].
+    style: Option<ParameterStyle>,
+    /// Specify names of unnamed fields with `names(...) attribute.`
+    names: Option<Vec<String>>,
+    /// See [`ParameterIn`].
+    parameter_in: Option<ParameterIn>,
+}
+
+impl IntoParamsAttr {
+    fn merge(mut self, other: Self) -> Self {
+        if other.style.is_some() {
+            self.style = other.style;
+        }
+
+        if other.names.is_some() {
+            self.names = other.names;
+        }
+
+        if other.parameter_in.is_some() {
+            self.parameter_in = other.parameter_in;
+        }
+
+        self
+    }
 }
 
 impl Parse for IntoParamsAttr {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-        const EXPECTED_ATTRIBUTE: &str = "unexpected token, expected: names";
+        const EXPECTED_ATTRIBUTE: &str =
+            "unexpected token, expected any of: names, style, parameter_in";
 
-        input
-            .parse::<Ident>()
-            .map_err(|error| Error::new(error.span(), format!("{EXPECTED_ATTRIBUTE}, {error}")))
-            .and_then(|ident| {
-                if ident != "names" {
-                    Err(Error::new(ident.span(), EXPECTED_ATTRIBUTE))
-                } else {
-                    Ok(ident)
-                }
+        let punctuated =
+            Punctuated::<IntoParamsAttr, Token![,]>::parse_terminated_with(input, |input| {
+                let ident: Ident = input.parse::<Ident>().map_err(|error| {
+                    Error::new(error.span(), format!("{EXPECTED_ATTRIBUTE}, {error}"))
+                })?;
+
+                Ok(match ident.to_string().as_str() {
+                    "names" => IntoParamsAttr {
+                        names: Some(
+                            parse_utils::parse_punctuated_within_parenthesis::<LitStr>(input)?
+                                .into_iter()
+                                .map(|name| name.value())
+                                .collect(),
+                        ),
+                        ..IntoParamsAttr::default()
+                    },
+                    "style" => {
+                        let style: ParameterStyle =
+                            parse_utils::parse_next(input, || input.parse::<ParameterStyle>())?;
+                        IntoParamsAttr {
+                            style: Some(style),
+                            ..IntoParamsAttr::default()
+                        }
+                    }
+                    "parameter_in" => {
+                        let parameter_in: ParameterIn =
+                            parse_utils::parse_next(input, || input.parse::<ParameterIn>())?;
+
+                        IntoParamsAttr {
+                            parameter_in: Some(parameter_in),
+                            ..IntoParamsAttr::default()
+                        }
+                    }
+                    _ => return Err(Error::new(ident.span(), EXPECTED_ATTRIBUTE)),
+                })
             })?;
 
-        Ok(IntoParamsAttr {
-            names: parse_utils::parse_punctuated_within_parenthesis::<LitStr>(input)?
-                .into_iter()
-                .map(|name| name.value())
-                .collect(),
-        })
+        let attributes: IntoParamsAttr = punctuated
+            .into_iter()
+            .fold(IntoParamsAttr::default(), |acc, next| acc.merge(next));
+
+        Ok(attributes)
     }
 }
 
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct IntoParams {
-    pub generics: Generics,
-    pub data: Data,
-    pub ident: Ident,
+    /// Attributes tagged on the whole struct or enum.
     pub attrs: Vec<Attribute>,
+    /// Generics required to complete the definition.
+    pub generics: Generics,
+    /// Data within the struct or enum.
+    pub data: Data,
+    /// Name of the struct or enum.
+    pub ident: Ident,
 }
 
 impl ToTokens for IntoParams {
@@ -57,7 +112,7 @@ impl ToTokens for IntoParams {
         let ident = &self.ident;
         let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
 
-        let into_params_attrs = &mut self
+        let into_params_attrs: Option<IntoParamsAttr> = self
             .attrs
             .iter()
             .find(|attr| attr.path.is_ident("into_params"))
@@ -66,27 +121,34 @@ impl ToTokens for IntoParams {
         let params = self
             .get_struct_fields(
                 &into_params_attrs
-                    .as_mut()
-                    .map(|params| params.names.as_ref()),
+                    .as_ref()
+                    .and_then(|params| params.names.as_ref()),
             )
             .enumerate()
             .map(|(index, field)| {
-                Param(
+                Param {
                     field,
-                    into_params_attrs
-                        .as_ref()
-                        .and_then(|param| param.names.get(index)),
-                )
+                    container_attributes: FieldParamContainerAttributes {
+                        style: into_params_attrs.as_ref().and_then(|attrs| attrs.style),
+                        name: into_params_attrs
+                            .as_ref()
+                            .and_then(|attrs| attrs.names.as_ref())
+                            .map(|names| names.get(index).unwrap_or_else(|| abort!(
+                                ident,
+                                "There is no name specified in the names(...) container attribute for tuple struct field {}",
+                                index
+                            ))),
+                        parameter_in: into_params_attrs.as_ref().and_then(|attrs| attrs.parameter_in),
+                    },
+                }
             })
             .collect::<Array<Param>>();
 
         tokens.extend(quote! {
             impl #impl_generics utoipa::IntoParams for #ident #ty_generics #where_clause {
-
                 fn into_params(parameter_in_provider: impl Fn() -> Option<utoipa::openapi::path::ParameterIn>) -> Vec<utoipa::openapi::path::Parameter> {
                     #params.to_vec()
                 }
-
             }
         });
     }
@@ -147,7 +209,7 @@ impl IntoParams {
             None => {
                 abort! {
                     ident,
-                    "struct with unnamed fields must have explisit name declarations.";
+                    "struct with unnamed fields must have explicit name declarations.";
                     help = "Try defining `#[into_params(names(...))]` over your type: {}", ident,
                 }
             }
@@ -155,25 +217,57 @@ impl IntoParams {
     }
 }
 
-struct Param<'a>(&'a Field, Option<&'a String>);
+#[cfg_attr(feature = "debug", derive(Debug))]
+pub struct FieldParamContainerAttributes<'a> {
+    /// See [`IntoParamsAttr::style`].
+    pub style: Option<ParameterStyle>,
+    /// See [`IntoParamsAttr::names`]. The name that applies to this field.
+    pub name: Option<&'a String>,
+    /// See [`IntoParamsAttr::parameter_in`].
+    pub parameter_in: Option<ParameterIn>,
+}
+
+#[cfg_attr(feature = "debug", derive(Debug))]
+struct Param<'a> {
+    /// Field in the container used to create a single parameter.
+    field: &'a Field,
+    /// Attributes on the container which are relevant for this macro.
+    container_attributes: FieldParamContainerAttributes<'a>,
+}
 
 impl ToTokens for Param<'_> {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        let unnamed_field_name = self.1;
-        let field = self.0;
+        let field = self.field;
         let ident = &field.ident;
         let name = ident
             .as_ref()
             .map(|ident| ident.to_string())
-            .or_else(|| unnamed_field_name.map(ToString::to_string))
-            .unwrap_or_default();
+            .or_else(|| self.container_attributes.name.cloned())
+            .unwrap_or_else(|| abort!(
+                field, "No name specified for unnamed field.";
+                help = "Try adding #[into_params(names(...))] container attribute to specify the name for this field"
+            ));
         let component_part = ComponentPart::from_type(&field.ty);
         let required: Required =
             (!matches!(&component_part.generic_type, Some(GenericType::Option))).into();
 
         tokens.extend(quote! { utoipa::openapi::path::ParameterBuilder::new()
             .name(#name)
-            .parameter_in(parameter_in_provider().unwrap_or_default())
+        });
+
+        tokens.extend(
+            if let Some(parameter_in) = self.container_attributes.parameter_in {
+                quote! {
+                    .parameter_in(#parameter_in)
+                }
+            } else {
+                quote! {
+                    .parameter_in(parameter_in_provider().unwrap_or_default())
+                }
+            },
+        );
+
+        tokens.extend(quote! {
             .required(#required)
         });
 
@@ -187,25 +281,27 @@ impl ToTokens for Param<'_> {
             })
         }
 
-        let parameter_ext = field
+        let mut parameter_ext = ParameterExt::from(&self.container_attributes);
+
+        // Apply the field attributes if they exist.
+        field
             .attrs
             .iter()
             .find(|attribute| attribute.path.is_ident("param"))
-            .map(|attribute| attribute.parse_args::<ParameterExt>().unwrap_or_abort());
+            .map(|attribute| attribute.parse_args::<ParameterExt>().unwrap_or_abort())
+            .map(|p| parameter_ext.merge(p));
 
-        if let Some(ext) = parameter_ext {
-            if let Some(ref style) = ext.style {
-                tokens.extend(quote! { .style(Some(#style)) });
-            }
-            if let Some(ref explode) = ext.explode {
-                tokens.extend(quote! { .explode(Some(#explode)) });
-            }
-            if let Some(ref allow_reserved) = ext.allow_reserved {
-                tokens.extend(quote! { .allow_reserved(Some(#allow_reserved)) });
-            }
-            if let Some(ref example) = ext.example {
-                tokens.extend(quote! { .example(Some(#example)) });
-            }
+        if let Some(ref style) = parameter_ext.style {
+            tokens.extend(quote! { .style(Some(#style)) });
+        }
+        if let Some(ref explode) = parameter_ext.explode {
+            tokens.extend(quote! { .explode(Some(#explode)) });
+        }
+        if let Some(ref allow_reserved) = parameter_ext.allow_reserved {
+            tokens.extend(quote! { .allow_reserved(Some(#allow_reserved)) });
+        }
+        if let Some(ref example) = parameter_ext.example {
+            tokens.extend(quote! { .example(Some(#example)) });
         }
 
         let param_type = ParamType(&component_part);

--- a/utoipa-swagger-ui/src/actix.rs
+++ b/utoipa-swagger-ui/src/actix.rs
@@ -23,9 +23,8 @@ impl HttpServiceFactory for SwaggerUi {
 
         let swagger_resource = Resource::new(self.path.as_ref())
             .guard(Get())
-            .app_data(Data::new(if let Some(mut config) = self.config {
-                config.urls = urls;
-                config
+            .app_data(Data::new(if let Some(config) = self.config {
+                config.configure_defaults(urls)
             } else {
                 Config::new(urls)
             }))

--- a/utoipa-swagger-ui/src/lib.rs
+++ b/utoipa-swagger-ui/src/lib.rs
@@ -1056,19 +1056,13 @@ impl<'a> Config<'a> {
 
 impl<'a> From<&'a str> for Config<'a> {
     fn from(s: &'a str) -> Self {
-        Self {
-            urls: vec![Url::from(s)],
-            ..Default::default()
-        }
+        Self::new([s]) 
     }
 }
 
 impl From<String> for Config<'_> {
     fn from(s: String) -> Self {
-        Self {
-            urls: vec![Url::from(s)],
-            ..Default::default()
-        }
+        Self::new([s]) 
     }
 }
 

--- a/utoipa-swagger-ui/src/rocket.rs
+++ b/utoipa-swagger-ui/src/rocket.rs
@@ -13,7 +13,7 @@ use rocket::{
     Data as RocketData, Request, Response, Route,
 };
 
-use crate::{Config, SwaggerFile, SwaggerUi, Url};
+use crate::{Config, SwaggerFile, SwaggerUi};
 
 impl From<SwaggerUi> for Vec<Route> {
     fn from(swagger_ui: SwaggerUi) -> Self {
@@ -34,11 +34,10 @@ impl From<SwaggerUi> for Vec<Route> {
             swagger_ui.path.as_ref(),
             ServeSwagger(
                 swagger_ui.path.clone(),
-                Arc::new(if let Some(mut config) = swagger_ui.config {
-                    config.urls = urls.collect();
-                    config
+                Arc::new(if let Some(config) = swagger_ui.config {
+                    config.configure_defaults(urls)
                 } else {
-                    Config::new(urls.collect::<Vec<Url>>())
+                    Config::new(urls)
                 }),
             ),
         ));


### PR DESCRIPTION
+  Add inline option to params(...) struct field attribute for `#[derive(IntoParams)]`,. This allows the schema for a type of a struct field to be inlined with the `IntoParams` derive.

TODO: 
- [ ] Wait for https://github.com/juhaku/utoipa/pull/150 to merge and retarget the PR